### PR TITLE
Fix verbatimModuleSyntax and erasableSyntaxOnly errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Decoration, EditorView, ViewPlugin, ViewUpdate, type DecorationSet } from '@codemirror/view';
 import { type Range } from '@codemirror/state';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
-import { HighlightStyle, LanguageDescription, LanguageSupport, syntaxHighlighting, syntaxTree, TagStyle } from '@codemirror/language';
+import { HighlightStyle, LanguageDescription, LanguageSupport, syntaxHighlighting, syntaxTree, type TagStyle } from '@codemirror/language';
 import { tags } from '@lezer/highlight';
 import { StrongEmphasis } from './markdown/bold';
 import { LinkDecoration } from './markdown/link';

--- a/src/markdown/base.ts
+++ b/src/markdown/base.ts
@@ -1,5 +1,5 @@
 import { Decoration, WidgetType } from "@codemirror/view"
-import { TagStyle } from "@codemirror/language"
+import { type TagStyle } from "@codemirror/language"
 import { type Range } from '@codemirror/state';
 
 export class HiddenWidget extends WidgetType {

--- a/src/markdown/headings.ts
+++ b/src/markdown/headings.ts
@@ -3,7 +3,7 @@ import { HiddenWidget, MarkdownDecoration } from './base';
 import { type Range } from '@codemirror/state';
 
 import { tags } from '@lezer/highlight';
-import { TagStyle } from '@codemirror/language';
+import { type TagStyle } from '@codemirror/language';
 
 export class HeadingDecoration extends MarkdownDecoration {
   constructor(level: 1|2|3|4|5|6) {

--- a/src/markdown/list-item.ts
+++ b/src/markdown/list-item.ts
@@ -4,8 +4,10 @@ import { type Range } from '@codemirror/state';
 import { tags } from '@lezer/highlight';
 
 class ListItemWidget extends WidgetType {
-  constructor(private level: number = 0) { 
-    super() 
+  level: number
+  constructor(level: number = 0) { 
+    super()
+    this.level = level
   }
 
   eq(other: ListItemWidget) { 


### PR DESCRIPTION
Fix TypeScript errors by using type-only imports and refactoring a parameter property to comply with `verbatimModuleSyntax` and `erasableSyntaxOnly`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbd4369f-1296-4ba3-8b9d-ba3f9a99ec8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cbd4369f-1296-4ba3-8b9d-ba3f9a99ec8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

