### PR TITLE
Configure vite base path for assets

### DIFF
--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  // Ensure assets are served from the repository subpath when deployed
+  base: '/cm-markdown/',
+});
+


### PR DESCRIPTION
Add `vite.config.ts` to the example app to correctly set the base path for subpath deployment.

The example hosted at `https://nanne.dev/cm-markdown/` was failing to load assets because the base path was not configured for subpath deployment, leading to incorrect asset URLs like `/assets/...` instead of `/cm-markdown/assets/...`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8be7a211-b1ba-45e2-9b34-492297dc23dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8be7a211-b1ba-45e2-9b34-492297dc23dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

